### PR TITLE
Add manual dim/restore logic for living room motion package

### DIFF
--- a/packages/sala_de_estar_motion_package_v7.yaml
+++ b/packages/sala_de_estar_motion_package_v7.yaml
@@ -1,0 +1,298 @@
+# ===============================
+# PACK: Sala de estar - Luces por movimiento (v7)
+# - Timer de apagado según parte del día
+# - Preaviso configurable que baja brillo 50%
+# - Snapshot al iniciar preaviso para restaurar estado
+# - Timers independientes: apagado_sala y preaviso_sala
+# - Transiciones configurables
+# ===============================
+
+---
+homeassistant:
+  customize: {}
+
+# ------- HELPERS -------
+# (Comenta si ya existen en otro archivo)
+input_number:
+  sala_off_manana:
+    name: Sala - Apagado mañana (min)
+    min: 1
+    max: 60
+    step: 1
+    unit_of_measurement: min
+    icon: mdi:white-balance-sunny
+  sala_off_mediodia:
+    name: Sala - Apagado mediodía (min)
+    min: 1
+    max: 60
+    step: 1
+    unit_of_measurement: min
+    icon: mdi:white-balance-sunny
+  sala_off_tarde:
+    name: Sala - Apagado tarde (min)
+    min: 1
+    max: 60
+    step: 1
+    unit_of_measurement: min
+    icon: mdi:weather-sunset
+  sala_off_noche:
+    name: Sala - Apagado noche (min)
+    min: 1
+    max: 60
+    step: 1
+    unit_of_measurement: min
+    icon: mdi:weather-night
+  sala_off_madrugada:
+    name: Sala - Apagado madrugada (min)
+    min: 1
+    max: 60
+    step: 1
+    unit_of_measurement: min
+    icon: mdi:weather-night
+  sala_preaviso:
+    name: Sala - Preaviso (min)
+    min: 1
+    max: 15
+    step: 1
+    unit_of_measurement: min
+    icon: mdi:timer-sand
+  sala_fade:
+    name: Sala - Transición (s)
+    min: 1
+    max: 30
+    step: 1
+    unit_of_measurement: s
+    icon: mdi:movie-roll
+
+# ------- INPUT TEXT -------
+input_text:
+  snapshot_luces_sala:
+    name: Sala - Luces snapshot
+    icon: mdi:text
+
+# ------- SCRIPTS -------
+script:
+  dim_step:
+    mode: parallel
+    fields:
+      entity_id:
+      target_pct:
+      duration:
+    sequence:
+      - variables:
+          steps: 10
+          start: "{{ state_attr(entity_id,'brightness')|int }}"
+          target: "{{ (start * target_pct / 100)|int }}"
+          step: "{{ (start - target) / steps }}"
+          delay_ms: "{{ (duration|int * 1000) / steps }}"
+      - repeat:
+          count: "{{ steps }}"
+          sequence:
+            - service: light.turn_on
+              target:
+                entity_id: "{{ entity_id }}"
+              data:
+                brightness: "{{ (start - step * repeat.index)|int }}"
+            - delay: "{{ delay_ms|int }}ms"
+  brighten_step:
+    mode: parallel
+    fields:
+      entity_id:
+      target:
+      duration:
+    sequence:
+      - variables:
+          steps: 10
+          start: "{{ state_attr(entity_id,'brightness')|int }}"
+          step: "{{ (target|int - start) / steps }}"
+          delay_ms: "{{ (duration|int * 1000) / steps }}"
+      - repeat:
+          count: "{{ steps }}"
+          sequence:
+            - service: light.turn_on
+              target:
+                entity_id: "{{ entity_id }}"
+              data:
+                brightness: "{{ (start + step * repeat.index)|int }}"
+            - delay: "{{ delay_ms|int }}ms"
+
+# ------- TIMERS -------
+timer:
+  apagado_sala:
+    name: Apagado - Sala de estar
+    restore: true
+  preaviso_sala:
+    name: Preaviso - Sala de estar
+    restore: true
+
+# ===============================
+# AUTOMATIZACIÓN PRINCIPAL
+# ===============================
+automation:
+  - id: sala_luces_movimiento_v7
+    alias: Sala - Luces por movimiento (v7)
+    mode: restart
+
+    trigger:
+      - platform: state
+        entity_id: binary_sensor.motion_sala
+        from: 'on'
+        to: 'off'
+        for: "00:00:05"
+
+    variables:
+      area_name: "sala de estar"
+      snapshot_id: "snapshot_sala_de_estar"
+
+      parte: "{{ states('sensor.parte_del_dia') | lower }}"
+      parte_norm: >
+        {{ parte | replace('á','a') | replace('é','e')
+                | replace('í','i') | replace('ó','o') | replace('ú','u') }}
+      mapa_apagado: >
+        {{ {
+            'manana': states('input_number.sala_off_manana')|int,
+            'mediodia': states('input_number.sala_off_mediodia')|int,
+            'tarde': states('input_number.sala_off_tarde')|int,
+            'noche': states('input_number.sala_off_noche')|int,
+            'madrugada': states('input_number.sala_off_madrugada')|int
+           } }}
+      apagado_seconds: >-
+        {{ mapa_apagado.get(parte_norm,
+                            states('input_number.sala_off_noche')|int) * 60 }}
+      preaviso_seconds: "{{ states('input_number.sala_preaviso')|int * 60 }}"
+      fade_seconds: "{{ states('input_number.sala_fade')|int }}"
+
+      timeout_preaviso: >-
+        {% set s = apagado_seconds|int - preaviso_seconds|int %}
+        {% if s < 0 %}{% set s = 0 %}{% endif %}
+        {{ '%02d:%02d:%02d' |
+           format((s // 3600), ((s % 3600) // 60), (s % 60)) }}
+      timeout_preaviso_only: >-
+        {% set s = preaviso_seconds|int %}
+        {{ '%02d:%02d:%02d' |
+           format((s // 3600), ((s % 3600) // 60), (s % 60)) }}
+
+      luces_area: >-
+        {{ expand(area_entities(area_name))
+           | selectattr('entity_id','search','^light\\.')
+           | map(attribute='entity_id') | list }}
+      luces_brillo: >-
+        {{ luces_area
+           | select('is_state','on')
+           | selectattr('attributes.supported_color_modes',
+                        'search','brightness')
+           | list }}
+
+    action:
+      # 1) Iniciar timer total de apagado
+      - service: timer.start
+        target:
+          entity_id: timer.apagado_sala
+        data:
+          duration: "{{ apagado_seconds }}"
+
+      # 2) Esperar hasta preaviso o movimiento
+      - wait_for_trigger:
+          - platform: state
+            entity_id: binary_sensor.motion_sala
+            to: 'on'
+        timeout: "{{ timeout_preaviso }}"
+        continue_on_timeout: true
+
+      # 3) Si hubo movimiento antes del preaviso, cancelar
+      - choose:
+          - conditions: "{{ wait.completed }}"
+            sequence:
+              - service: timer.cancel
+                target:
+                  entity_id: timer.apagado_sala
+              - stop: "Movimiento detectado antes del preaviso"
+
+      # 4) Preaviso: snapshot, dim y timer para tarjeta
+      - service: scene.create
+        data:
+          scene_id: "{{ snapshot_id }}"
+          snapshot_entities: "{{ luces_area }}"
+      - service: input_text.set_value
+        data:
+          entity_id: input_text.snapshot_luces_sala
+          value: >-
+            {% set ns = namespace(d={}) %}
+              {% for l in luces_brillo %}
+                {% set ns.d = ns.d | combine({
+                  l: state_attr(l,'brightness')|int
+                }) %}
+              {% endfor %}
+            {{ ns.d | to_json }}
+      - repeat:
+          for_each: "{{ luces_brillo }}"
+          sequence:
+            - service: script.dim_step
+              data:
+                entity_id: "{{ repeat.item }}"
+                target_pct: 50
+                duration: "{{ fade_seconds }}"
+      - service: timer.start
+        target:
+          entity_id: timer.preaviso_sala
+        data:
+          duration: "{{ preaviso_seconds }}"
+
+      # 5) Esperar movimiento durante preaviso
+      - wait_for_trigger:
+          - platform: state
+            entity_id: binary_sensor.motion_sala
+            to: 'on'
+        timeout: "{{ timeout_preaviso_only }}"
+        continue_on_timeout: true
+
+      # 6) Si hay movimiento durante preaviso, restaurar
+      - choose:
+          - conditions: "{{ wait.completed }}"
+            sequence:
+              - variables:
+                  snapshot_map: >-
+                    {{ states('input_text.snapshot_luces_sala') | from_json }}
+              - repeat:
+                  for_each: "{{ snapshot_map.keys() | list }}"
+                  sequence:
+                    - service: script.brighten_step
+                      data:
+                        entity_id: "{{ repeat.item }}"
+                        target: "{{ snapshot_map[repeat.item] }}"
+                        duration: "{{ fade_seconds }}"
+              - service: scene.turn_on
+                target:
+                  entity_id: "scene.{{ snapshot_id }}"
+              - service: input_text.set_value
+                data:
+                  entity_id: input_text.snapshot_luces_sala
+                  value: ''
+              - service: timer.cancel
+                target:
+                  entity_id:
+                    - timer.apagado_sala
+                    - timer.preaviso_sala
+              - stop: "Movimiento detectado durante preaviso"
+
+      # 7) Apagar luces con transición
+      - repeat:
+          for_each: "{{ luces_brillo }}"
+          sequence:
+            - service: script.dim_step
+              data:
+                entity_id: "{{ repeat.item }}"
+                target_pct: 0
+                duration: "{{ fade_seconds }}"
+            - service: light.turn_off
+              target:
+                entity_id: "{{ repeat.item }}"
+      - service: input_text.set_value
+        data:
+          entity_id: input_text.snapshot_luces_sala
+          value: ''
+      - service: timer.cancel
+        target:
+          entity_id:
+            - timer.apagado_sala
+            - timer.preaviso_sala


### PR DESCRIPTION
## Summary
- add step-based dim and brighten scripts for lights without transition support
- store snapshot brightness in helper for gradual restoration
- use scripts in sala de estar motion package for smooth fade down and up

## Testing
- `yamllint packages/sala_de_estar_motion_package_v7.yaml`
- `hass --script check_config -c .`

------
https://chatgpt.com/codex/tasks/task_e_68a14c6906a4832c97750027883625e3