### PR TITLE
Add field descriptions to dim and brighten scripts

### DIFF
--- a/packages/sala_de_estar_motion_package_v7.yaml
+++ b/packages/sala_de_estar_motion_package_v7.yaml
@@ -76,8 +76,17 @@ script:
     mode: parallel
     fields:
       entity_id:
+        name: Light entity
+        description: "Light entity to control"
+        example: light.living_room
       target_pct:
+        name: Target brightness percentage
+        description: "Target brightness percentage"
+        example: 50
       duration:
+        name: Fade duration
+        description: "Fade duration in seconds"
+        example: 5
     sequence:
       - variables:
           steps: 10
@@ -98,8 +107,17 @@ script:
     mode: parallel
     fields:
       entity_id:
+        name: Light entity
+        description: "Light entity to control"
+        example: light.living_room
       target:
+        name: Target brightness value
+        description: "Target brightness value"
+        example: 50
       duration:
+        name: Fade duration
+        description: "Fade duration in seconds"
+        example: 5
     sequence:
       - variables:
           steps: 10


### PR DESCRIPTION
## Summary
- document dim_step and brighten_step script fields in sala_de_estar package
- provide field names for clarity

## Testing
- `hass --script check_config -c .` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a165b2b87c832c87d99cdec8d24def