### PR TITLE
Use secret for Home Assistant API token

### DIFF
--- a/packages/git_sync.yaml
+++ b/packages/git_sync.yaml
@@ -13,18 +13,18 @@ shell_command:
         git add . &&
         git commit -m \"Commit desde Home Assistant - $(date '+%Y-%m-%d %H:%M:%S')\" -m \"Archivos: $CHANGES\" &&
         if git push origin main; then
-          curl -s -X POST -H 'Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiI4YzY1MjEyYTU2N2Y0NDUzYjczYTVkOTJlYmRiMTQ4NiIsImlhdCI6MTc1NTE0ODQyOSwiZXhwIjoyMDcwNTA4NDI5fQ.F3uDb02YtUclcLvivzeoPGzxyye23-cWsZRssEsvooc' \
+          curl -s -X POST -H 'Authorization: Bearer !secret ha_api_token' \
                -H 'Content-Type: application/json' \
                -d '{\"title\": \"Git Push\", \"message\": \"Push a GitHub completado con éxito\"}' \
                http://192.168.0.202:8123/api/services/persistent_notification/create
         else
-          curl -s -X POST -H 'Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiI4YzY1MjEyYTU2N2Y0NDUzYjczYTVkOTJlYmRiMTQ4NiIsImlhdCI6MTc1NTE0ODQyOSwiZXhwIjoyMDcwNTA4NDI5fQ.F3uDb02YtUclcLvivzeoPGzxyye23-cWsZRssEsvooc' \
+          curl -s -X POST -H 'Authorization: Bearer !secret ha_api_token' \
                -H 'Content-Type: application/json' \
                -d '{\"title\": \"Git Push\", \"message\": \"Error al hacer push a GitHub\"}' \
                http://192.168.0.202:8123/api/services/persistent_notification/create
         fi
       else
-        curl -s -X POST -H 'Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiI4YzY1MjEyYTU2N2Y0NDUzYjczYTVkOTJlYmRiMTQ4NiIsImlhdCI6MTc1NTE0ODQyOSwiZXhwIjoyMDcwNTA4NDI5fQ.F3uDb02YtUclcLvivzeoPGzxyye23-cWsZRssEsvooc' \
+        curl -s -X POST -H 'Authorization: Bearer !secret ha_api_token' \
              -H 'Content-Type: application/json' \
              -d '{\"title\": \"Git Push\", \"message\": \"No hay cambios para subir\"}' \
              http://192.168.0.202:8123/api/services/persistent_notification/create
@@ -37,12 +37,12 @@ shell_command:
       GIT_SSH_COMMAND='ssh -i /config/.ssh/id_ed25519 -o StrictHostKeyChecking=no' &&
       cd /config &&
       if git pull origin main; then
-        curl -s -X POST -H 'Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiI4YzY1MjEyYTU2N2Y0NDUzYjczYTVkOTJlYmRiMTQ4NiIsImlhdCI6MTc1NTE0ODQyOSwiZXhwIjoyMDcwNTA4NDI5fQ.F3uDb02YtUclcLvivzeoPGzxyye23-cWsZRssEsvooc' \
+        curl -s -X POST -H 'Authorization: Bearer !secret ha_api_token' \
              -H 'Content-Type: application/json' \
              -d '{\"title\": \"Git Pull\", \"message\": \"Pull de GitHub completado con éxito\"}' \
              http://192.168.0.202:8123/api/services/persistent_notification/create
       else
-        curl -s -X POST -H 'Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiI4YzY1MjEyYTU2N2Y0NDUzYjczYTVkOTJlYmRiMTQ4NiIsImlhdCI6MTc1NTE0ODQyOSwiZXhwIjoyMDcwNTA4NDI5fQ.F3uDb02YtUclcLvivzeoPGzxyye23-cWsZRssEsvooc' \
+        curl -s -X POST -H 'Authorization: Bearer !secret ha_api_token' \
              -H 'Content-Type: application/json' \
              -d '{\"title\": \"Git Pull\", \"message\": \"Error al hacer pull de GitHub\"}' \
              http://192.168.0.202:8123/api/services/persistent_notification/create
@@ -56,7 +56,7 @@ shell_command:
       cd /config &&
       git fetch origin main &&
       git reset --hard origin/main &&
-      curl -s -X POST -H 'Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiI4YzY1MjEyYTU2N2Y0NDUzYjczYTVkOTJlYmRiMTQ4NiIsImlhdCI6MTc1NTE0ODQyOSwiZXhwIjoyMDcwNTA4NDI5fQ.F3uDb02YtUclcLvivzeoPGzxyye23-cWsZRssEsvooc' \
+      curl -s -X POST -H 'Authorization: Bearer !secret ha_api_token' \
            -H 'Content-Type: application/json' \
            -d '{\"title\": \"Git Pull Forzado\", \"message\": \"Pull forzado completado, cambios locales descartados\"}' \
            http://192.168.0.202:8123/api/services/persistent_notification/create


### PR DESCRIPTION
## Summary
- reference Home Assistant API token via secret in git sync package

## Testing
- `yamllint packages/git_sync.yaml`


------
https://chatgpt.com/codex/tasks/task_e_68a392672760832ca1ee019586959c79