### PR TITLE
Support color or effect when turning on Luz Rack light

### DIFF
--- a/packages/luz_rack.yaml
+++ b/packages/luz_rack.yaml
@@ -172,11 +172,31 @@ template:
             target: { entity_id: input_boolean.luz_rack_guard }
           - service: script.luz_rack_on
           - delay: "00:00:00.3"
-          - service: script.luz_rack_set_color
-          # Al encender por color, el efecto activo pasa a 'none'
-          - service: input_select.select_option
-            target: { entity_id: input_select.luz_rack_effect }
-            data: { option: "none" }
+          - choose:
+              - conditions:
+                  - condition: template
+                    value_template: "{{ effect is defined }}"
+                sequence:
+                  - service: script.luz_rack_set_effect
+                    data:
+                      effect: "{{ effect }}"
+              - conditions:
+                  - condition: template
+                    value_template: "{{ color is defined }}"
+                sequence:
+                  - service: script.luz_rack_set_color
+                    data:
+                      color: "{{ color }}"
+                  # Al encender por color, el efecto activo pasa a 'none'
+                  - service: input_select.select_option
+                    target: { entity_id: input_select.luz_rack_effect }
+                    data: { option: "none" }
+            default:
+              - service: script.luz_rack_set_color
+              # Al encender por color, el efecto activo pasa a 'none'
+              - service: input_select.select_option
+                target: { entity_id: input_select.luz_rack_effect }
+                data: { option: "none" }
           - service: input_boolean.turn_off
             target: { entity_id: input_boolean.luz_rack_guard }
 


### PR DESCRIPTION
## Summary
- allow `light.luz_rack` to accept `color` or `effect` when calling `light.turn_on`
- update helper selections to match applied state

## Testing
- `yamllint -d '{extends: relaxed, rules: {line-length: {max: 120}}}' packages/luz_rack.yaml && echo LINT_OK`
- `hass -c . --script check_config` *(fails: Unable to install package paho-mqtt==1.6.1: ERROR: Operation cancelled by user)*

------
https://chatgpt.com/codex/tasks/task_e_68b083f48b90832c96721c58ca68d483